### PR TITLE
Update README.md

### DIFF
--- a/pyecoop/README.md
+++ b/pyecoop/README.md
@@ -16,7 +16,7 @@ Notebook used for the  Climate forcing UseCase :
 
 - [executed](http://nbviewer.ipython.org/github/epifanio/ecoop-1/blob/master/pyecoop/notebook/ESR_Test_executed.ipynb)
 
-- [API documentation](http://www.epinux.com/shared/pyecoop_doc/)
+- [API documentation](http://ecoop.tw.rpi.edu/)
 
 --- 
 


### PR DESCRIPTION
replaced http://www.epinux.com/shared/pyecoop_doc/ with http://ecoop.tw.rpi.edu/
